### PR TITLE
Teaching plan configuration

### DIFF
--- a/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/controller/TopicManagementController.java
+++ b/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/controller/TopicManagementController.java
@@ -1,0 +1,76 @@
+package com.cenfotec.p3.neuralforge_api.controller;
+
+import com.cenfotec.p3.neuralforge_api.model.resource.CourseTopicResource;
+import com.cenfotec.p3.neuralforge_api.model.resource.TeachingProjectResource;
+import com.cenfotec.p3.neuralforge_api.service.TopicManagementService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller for managing teaching project topics.
+ * 
+ * @author Enrique Alpízar
+ * @version 1.0
+ */
+@RestController
+@RequestMapping("/topic-management")
+public class TopicManagementController {
+
+    @Autowired
+    private TopicManagementService topicManagementService;
+
+    /**
+     * Toggles the locked state of a topic.
+     *
+     * @param topicId The ID of the topic to toggle lock state.
+     * @return The updated topic resource.
+     */
+    @PutMapping("/topics/{topicId}/toggle-lock")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<CourseTopicResource> toggleTopicLock(@PathVariable String topicId) {
+        return ResponseEntity.ok(topicManagementService.toggleTopicLock(topicId));
+    }
+    
+    /**
+     * Moves a topic from one session to another.
+     *
+     * @param topicId The ID of the topic to move.
+     * @param targetWeekNumber The target week number.
+     * @param targetSessionId The target session ID.
+     * @return The updated teaching project resource.
+     */
+    @PutMapping("/topics/{topicId}/move-to-session")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TeachingProjectResource> moveTopicToSession(
+            @PathVariable String topicId,
+            @RequestParam int targetWeekNumber,
+            @RequestParam String targetSessionId) {
+        return ResponseEntity.ok(topicManagementService.moveTopicToSession(topicId, targetWeekNumber, targetSessionId));
+    }
+    
+    /**
+     * Moves a topic up in its session (decrease order index).
+     *
+     * @param topicId The ID of the topic to move up.
+     * @return The updated teaching project resource.
+     */
+    @PutMapping("/topics/{topicId}/move-up")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TeachingProjectResource> moveTopicUp(@PathVariable String topicId) {
+        return ResponseEntity.ok(topicManagementService.moveTopicUp(topicId));
+    }
+    
+    /**
+     * Moves a topic down in its session (increase order index).
+     *
+     * @param topicId The ID of the topic to move down.
+     * @return The updated teaching project resource.
+     */
+    @PutMapping("/topics/{topicId}/move-down")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<TeachingProjectResource> moveTopicDown(@PathVariable String topicId) {
+        return ResponseEntity.ok(topicManagementService.moveTopicDown(topicId));
+    }
+}

--- a/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/repository/CourseTopicRepository.java
+++ b/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/repository/CourseTopicRepository.java
@@ -1,0 +1,15 @@
+package com.cenfotec.p3.neuralforge_api.repository;
+
+import com.cenfotec.p3.neuralforge_api.model.entity.CourseTopicEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for CourseTopicEntity.
+ * 
+ * @author Enrique Alpízar
+ * @version 1.0
+ */
+@Repository
+public interface CourseTopicRepository extends JpaRepository<CourseTopicEntity, String> {
+}

--- a/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/service/TeachingProjectService.java
+++ b/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/service/TeachingProjectService.java
@@ -32,9 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.DayOfWeek;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -218,7 +216,7 @@ public class TeachingProjectService {
      * @param projectOwnerId The ID of the project owner.
      * @throws ResponseStatusException if the user is not authorized.
      */
-    private void validateProjectOwnership(String projectOwnerId) {
+    protected void validateProjectOwnership(String projectOwnerId) {
         UserEntity currentUser = (UserEntity) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         if (!currentUser.getId().equals(projectOwnerId) && currentUser.getRole().getName() != UserRoleEnum.ROLE_ADMINISTRATOR) {
@@ -237,40 +235,6 @@ public class TeachingProjectService {
      * 5. Saves the structured data and the raw response
      *
      * @param teachingProjectId The ID of the teaching project.
-     * @return The updated teaching project resource with the generated schedule.
-     * @throws ResponseStatusException if the project is not found, the user is not authorized,
-     *         there is an issue with materials processing, or there is an error in AI response.
-     */
-    @Transactional
-    public TeachingProjectResource generateTeachingSchedule(String teachingProjectId) {
-        // Retrieve teaching project
-        TeachingProjectEntity project = teachingProjectRepository.findById(teachingProjectId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, 
-                    "Teaching project not found with id: " + teachingProjectId));
-
-        validateProjectOwnership(project.getCreatorUserId());
-        
-        // Extract text from all materials
-        String materialsText = extractTextFromMaterials(project);
-        
-        // Generate the prompt for DeepSeek API
-        String prompt = generateCourseSchedulePrompt(project, materialsText);
-        
-        try {
-            // Send prompt to DeepSeek API and get the response
-            String responseJson = dynamicContentService.sendToDeepSeekAndGetRawResponse(prompt);
-            
-            // Parse the response and save the schedule
-            return processAndSaveSchedule(project, responseJson);
-        } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
-                "Error processing DeepSeek AI response: " + e.getMessage());
-        }
-    }
-    
-    /**
-     * Extracts text content from all materials associated with a teaching project.
-     * 
      * @param project The teaching project entity.
      * @return The extracted text from all materials.
      * @throws ResponseStatusException if there is an error extracting text or no content is available.
@@ -320,14 +284,60 @@ public class TeachingProjectService {
     }
     
     /**
+     * Generates a teaching schedule for a project using DeepSeek AI.
+     *
+     * @param teachingProjectId The ID of the teaching project.
+     * @return The teaching project resource with the generated schedule.
+     */
+    @Transactional
+    public TeachingProjectResource generateTeachingSchedule(String teachingProjectId) {
+        // Retrieve teaching project
+        TeachingProjectEntity project = teachingProjectRepository.findById(teachingProjectId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, 
+                    "Teaching project not found with id: " + teachingProjectId));
+
+        validateProjectOwnership(project.getCreatorUserId());
+        
+        // Collect locked topics if any exist
+        List<CourseTopicEntity> lockedTopics = new ArrayList<>();
+        if (project.getWeeks() != null && !project.getWeeks().isEmpty()) {
+            for (CourseWeekEntity week : project.getWeeks()) {
+                for (ClassSessionEntity session : week.getClassSessions()) {
+                    lockedTopics.addAll(session.getTopics().stream()
+                        .filter(CourseTopicEntity::getTeacherLocked)
+                        .collect(Collectors.toList()));
+                }
+            }
+        }
+        
+        // Extract text from all materials
+        String materialsText = extractTextFromMaterials(project);
+        
+        // Generate the prompt for DeepSeek API
+        String prompt = generateCourseSchedulePrompt(project, materialsText, lockedTopics);
+        
+        try {
+            // Send prompt to DeepSeek API and get the response
+            String responseJson = dynamicContentService.sendToDeepSeekAndGetRawResponse(prompt);
+            
+            // Parse the response and save the schedule, preserving locked topics
+            return processAndSaveSchedule(project, responseJson, lockedTopics);
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                "Error processing DeepSeek AI response: " + e.getMessage());
+        }
+    }
+    
+    /**
      * Processes the AI response, saves the raw JSON, creates the course structure, and persists everything.
      * 
      * @param project The teaching project entity.
      * @param responseJson The JSON response from DeepSeek AI.
+     * @param lockedTopics List of locked topics to preserve during regeneration.
      * @return The updated teaching project resource.
      * @throws IOException if there is an error parsing the JSON response.
      */
-    private TeachingProjectResource processAndSaveSchedule(TeachingProjectEntity project, String responseJson) throws IOException {
+    private TeachingProjectResource processAndSaveSchedule(TeachingProjectEntity project, String responseJson, List<CourseTopicEntity> lockedTopics) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode responseNode = objectMapper.readTree(responseJson);
         
@@ -335,11 +345,38 @@ public class TeachingProjectService {
         String filePath = saveRawResponseToFile(project, responseJson);
         System.out.println("Raw JSON response saved to: " + filePath);
         
+        // Create a map of locked topic titles to make identification easier during processing
+        Map<String, Boolean> lockedTopicTitles = lockedTopics.stream()
+            .collect(Collectors.toMap(CourseTopicEntity::getTitle, topic -> true, (a, b) -> a));
+            
+        // Also store a map of original locked topics by their session ID for validation
+        Map<String, List<CourseTopicEntity>> lockedTopicsBySessionId = lockedTopics.stream()
+            .collect(Collectors.groupingBy(topic -> topic.getClassSession().getId()));
+        
+        // Store the original locked topic information for validation
+        // This creates a map of original locked topics by week number and day of week
+        Map<Integer, Map<DayOfWeek, List<CourseTopicEntity>>> originalLockedTopicsByWeekAndDay = new HashMap<>();
+        for (CourseTopicEntity topic : lockedTopics) {
+            int weekNumber = topic.getClassSession().getCourseWeek().getWeekNumber();
+            DayOfWeek dayOfWeek = topic.getClassSession().getDayOfWeek();
+            
+            originalLockedTopicsByWeekAndDay.computeIfAbsent(weekNumber, k -> new HashMap<>())
+                .computeIfAbsent(dayOfWeek, k -> new ArrayList<>())
+                .add(topic);
+        }
+        
         // Clear existing schedule data if any
         project.getWeeks().clear();
         
         // Create and save course weeks, class sessions and topics based on the response
-        processCourseStructure(project, responseNode);
+        // The AI should have already incorporated the locked topics into the schedule based on our prompt
+        // We'll also preserve the locked status for any topics that match the original locked topics
+        processCourseStructure(project, responseNode, lockedTopicTitles);
+        
+        // VALIDATION STEP: Ensure that all locked topics were preserved in their original sessions
+        if (!lockedTopics.isEmpty()) {
+            validateLockedTopicsPreservation(project, originalLockedTopicsByWeekAndDay, lockedTopics);
+        }
         
         // Save the project with its new schedule
         TeachingProjectEntity savedProject = teachingProjectRepository.save(project);
@@ -375,9 +412,10 @@ public class TeachingProjectService {
      *
      * @param project The teaching project entity.
      * @param materialsText The extracted text from project materials.
+     * @param lockedTopics List of locked topics that should be preserved in the new schedule.
      * @return A prompt string for DeepSeek AI.
      */
-    private String generateCourseSchedulePrompt(TeachingProjectEntity project, String materialsText) {
+    private String generateCourseSchedulePrompt(TeachingProjectEntity project, String materialsText, List<CourseTopicEntity> lockedTopics) {
         List<String> selectedDaysList = getSelectedDaysList(project.getSelectedDays());
         int hoursPerWeek = selectedDaysList.size() * project.getDailyHours();
         
@@ -393,8 +431,8 @@ public class TeachingProjectService {
         // Course content section
         promptBuilder.append("Course Content:\n").append(materialsText).append("\n\n");
         
-        // Instructions section
-        appendInstructions(promptBuilder);
+        // Instructions section with locked topics if any
+        appendInstructions(promptBuilder, lockedTopics);
         
         // Response format section
         appendResponseFormat(promptBuilder);
@@ -435,6 +473,9 @@ public class TeachingProjectService {
      */
     private void appendCourseDetails(StringBuilder promptBuilder, TeachingProjectEntity project, 
                                     List<String> selectedDaysList, int hoursPerWeek) {
+        // Calculate minutes per session for clarity
+        int minutesPerSession = project.getDailyHours() * 60;
+        
         promptBuilder.append("Course Details:\n")
                     .append("- Course Name: ").append(project.getName()).append("\n")
                     .append("- Course Description: ").append(project.getDescription()).append("\n")
@@ -442,16 +483,20 @@ public class TeachingProjectService {
                     .append("- End Date: ").append(project.getEndDate()).append("\n")
                     .append("- Total Weeks: ").append(project.getWeeksCount()).append("\n")
                     .append("- Teaching Days: ").append(String.join(", ", selectedDaysList)).append("\n")
-                    .append("- Hours Per Session: ").append(project.getDailyHours()).append("\n")
-                    .append("- Total Hours Per Week: ").append(hoursPerWeek).append("\n\n");
+                    .append("- Hours Per Session: ").append(project.getDailyHours()).append(" hours (")
+                    .append(minutesPerSession).append(" minutes)\n")
+                    .append("- Total Hours Per Week: ").append(hoursPerWeek).append("\n")
+                    .append("- IMPORTANT: The sum of all topic durations for a single class session MUST EQUAL ")
+                    .append(minutesPerSession).append(" minutes exactly.\n\n");
     }
     
     /**
-     * Appends instructions to the prompt builder.
+     * Appends instructions to the prompt builder, including information about locked topics.
      * 
      * @param promptBuilder The StringBuilder to append to.
+     * @param lockedTopics List of locked topics that should be preserved in the new schedule
      */
-    private void appendInstructions(StringBuilder promptBuilder) {
+    private void appendInstructions(StringBuilder promptBuilder, List<CourseTopicEntity> lockedTopics) {
         promptBuilder.append("Instructions:\n")
                     .append("1. Create a comprehensive teaching schedule that covers the entire course content over the specified weeks.\n")
                     .append("2. Divide the content logically across the weeks, ensuring proper sequencing of topics.\n")
@@ -459,7 +504,80 @@ public class TeachingProjectService {
                     .append("4. Each topic should include a title and a brief description.\n")
                     .append("5. Ensure the distribution of content is balanced across sessions, with approximately equal workloads.\n")
                     .append("6. Consider the natural progression of learning, starting with fundamentals and building up to advanced concepts.\n")
-                    .append("7. IMPORTANT: The orderIndex for topics should restart from 1 for each class session. For example, each session should have topics with orderIndex 1, 2, etc., rather than continuing from the previous session.\n\n");
+                    .append("7. IMPORTANT: The orderIndex for topics should restart from 1 for each class session. For example, each session should have topics with orderIndex 1, 2, etc., rather than continuing from the previous session.\n")
+                    .append("8. CRITICAL - TIME CONSTRAINTS: The sum of durationMinutes for all topics in a class session MUST EQUAL EXACTLY the total minutes available for that session. ")
+                    .append("For example, if a session is 2 hours (120 minutes), the total duration of all topics in that session must be exactly 120 minutes.\n")
+                    .append("9. TOPIC DIVISION REQUIREMENT: Each class session MUST have at least 2-4 separate topics. Never create a single topic that consumes the entire session time. ")
+                    .append("Break down long topics into subtopics with their own titles, descriptions, and appropriate durations.\n");
+        
+        // Add locked topics to instructions if any exist
+        if (lockedTopics != null && !lockedTopics.isEmpty()) {
+            promptBuilder.append("\nLOCKED TOPICS:\n")
+                        .append("The following topics have been locked by the teacher and MUST be preserved EXACTLY as listed below. ")
+                        .append("⚠️ FAILURE TO FOLLOW THESE RULES WILL RESULT IN AN UNUSABLE SCHEDULE. ⚠️\n\n")
+                        .append("MANDATORY RULES FOR LOCKED TOPICS (THESE OVERRIDE ALL OTHER INSTRUCTIONS):\n")
+                        .append("1. LOCKED TOPICS MUST REMAIN IN THEIR EXACT ORIGINAL LOCATION - same week, same day, same class session.\n")
+                        .append("2. LOCKED TOPICS CANNOT BE MOVED OR MERGED under any circumstances.\n")
+                        .append("3. LOCKED TOPICS MUST MAINTAIN THEIR EXACT ORIGINAL DURATION - do not shorten or lengthen them.\n")
+                        .append("4. If a session has multiple locked topics, ALL of those locked topics must be included in that same session.\n")
+                        .append("5. SPECIAL CASE HANDLING: If the locked topics in a session already EXCEED the session duration, KEEP ALL the locked topics anyway.\n")
+                        .append("   In this case, you should NOT add any additional topics to that session.\n")
+                        .append("6. NORMAL CASE: When locked topics do NOT exceed session duration, adjust the remaining time with non-locked topics \n")
+                        .append("   to exactly fit the session duration (e.g., in a 120-minute session with 60 minutes of locked topics, \n")
+                        .append("   add new topics that total exactly 60 more minutes).\n\n");
+            
+            // Group locked topics by week and day for more precise organization
+            Map<Integer, Map<DayOfWeek, List<CourseTopicEntity>>> topicsByWeekAndDay = new HashMap<>();
+            
+            // Organize topics by week number and day of week
+            for (CourseTopicEntity topic : lockedTopics) {
+                int weekNumber = topic.getClassSession().getCourseWeek().getWeekNumber();
+                DayOfWeek dayOfWeek = topic.getClassSession().getDayOfWeek();
+                
+                topicsByWeekAndDay.computeIfAbsent(weekNumber, k -> new HashMap<>())
+                    .computeIfAbsent(dayOfWeek, k -> new ArrayList<>())
+                    .add(topic);
+            }
+            
+            // Output locked topics organized by week and day
+            for (Map.Entry<Integer, Map<DayOfWeek, List<CourseTopicEntity>>> weekEntry : topicsByWeekAndDay.entrySet()) {
+                int weekNumber = weekEntry.getKey();
+                promptBuilder.append("WEEK ").append(weekNumber).append(":\n");
+                
+                for (Map.Entry<DayOfWeek, List<CourseTopicEntity>> dayEntry : weekEntry.getValue().entrySet()) {
+                    DayOfWeek dayOfWeek = dayEntry.getKey();
+                    List<CourseTopicEntity> topicsForDay = dayEntry.getValue();
+                    
+                    promptBuilder.append("  ").append(dayOfWeek.toString()).append(" session:\n");
+                    
+                    // Calculate the total locked time for this session
+                    int totalLockedMinutes = topicsForDay.stream()
+                        .mapToInt(CourseTopicEntity::getDurationMinutes)
+                        .sum();
+                    
+                    // Get session ID for reference
+                    String sessionId = topicsForDay.get(0).getClassSession().getId();
+                    
+                    promptBuilder.append("  Session ID: ").append(sessionId).append("\n")
+                                .append("  Total locked time for this session: ").append(totalLockedMinutes).append(" minutes\n");
+                    
+                    // List all locked topics for this session
+                    for (CourseTopicEntity topic : topicsForDay) {
+                        promptBuilder.append("  - ID: ").append(topic.getId())
+                                    .append(", Title: \"").append(topic.getTitle()).append("\", ")
+                                    .append("Description: \"").append(topic.getDescription()).append("\", ")
+                                    .append("Duration: ").append(topic.getDurationMinutes()).append(" minutes, ")
+                                    .append("Order: ").append(topic.getOrderIndex()).append("\n");
+                    }
+                    promptBuilder.append("\n");
+                }
+            }
+            
+            promptBuilder.append("⚠️ IMPORTANT REMINDER: ALL of the locked topics above MUST appear in your schedule in their EXACT original location.\n")
+                       .append("Adjust other topics accordingly while keeping class session durations correct.\n\n");
+        }
+        
+        promptBuilder.append("\n");
     }
     
     /**
@@ -520,8 +638,9 @@ public class TeachingProjectService {
      *
      * @param project The teaching project entity.
      * @param responseNode The JsonNode containing the parsed response.
+     * @param lockedTopicTitles Map of topic titles that should remain locked
      */
-    private void processCourseStructure(TeachingProjectEntity project, JsonNode responseNode) {
+    private void processCourseStructure(TeachingProjectEntity project, JsonNode responseNode, Map<String, Boolean> lockedTopicTitles) {
         JsonNode weeksNode = responseNode.path("weeks");
         if (weeksNode.isArray()) {
             for (JsonNode weekNode : weeksNode) {
@@ -529,7 +648,7 @@ public class TeachingProjectService {
                 
                 JsonNode sessionsNode = weekNode.path("classSessions");
                 if (sessionsNode.isArray()) {
-                    processClassSessions(weekEntity, sessionsNode);
+                    processClassSessions(weekEntity, sessionsNode, lockedTopicTitles);
                 }
                 
                 project.getWeeks().add(weekEntity);
@@ -559,8 +678,9 @@ public class TeachingProjectService {
      * 
      * @param weekEntity The course week entity.
      * @param sessionsNode The JSON node containing class sessions.
+     * @param lockedTopicTitles Map of topic titles that should remain locked
      */
-    private void processClassSessions(CourseWeekEntity weekEntity, JsonNode sessionsNode) {
+    private void processClassSessions(CourseWeekEntity weekEntity, JsonNode sessionsNode, Map<String, Boolean> lockedTopicTitles) {
         for (JsonNode sessionNode : sessionsNode) {
             String dayOfWeekStr = sessionNode.path("dayOfWeek").asText();
             
@@ -570,7 +690,7 @@ public class TeachingProjectService {
                 
                 JsonNode topicsNode = sessionNode.path("topics");
                 if (topicsNode.isArray()) {
-                    processTopics(sessionEntity, topicsNode);
+                    processTopics(sessionEntity, topicsNode, lockedTopicTitles);
                 }
                 
                 weekEntity.getClassSessions().add(sessionEntity);
@@ -597,17 +717,133 @@ public class TeachingProjectService {
     }
     
     /**
+     * Validates that all locked topics were properly preserved in the new schedule.
+     * This acts as a safety net to ensure the AI didn't move or remove any locked topics.
+     * If validation fails, it throws an exception rather than saving an invalid schedule.
+     * 
+     * @param project The teaching project with the newly generated schedule
+     * @param originalLockedTopicsByWeekAndDay Map of original locked topics by week and day
+     * @param originalLockedTopics The complete list of original locked topics
+     * @throws ResponseStatusException if locked topics weren't properly preserved
+     */
+    private void validateLockedTopicsPreservation(TeachingProjectEntity project, 
+                                               Map<Integer, Map<DayOfWeek, List<CourseTopicEntity>>> originalLockedTopicsByWeekAndDay,
+                                               List<CourseTopicEntity> originalLockedTopics) {
+        // Track which original locked topics we've successfully found
+        Set<String> foundLockedTopicIds = new HashSet<>();
+        
+        // Get count of locked topics for validation
+        int originalLockedTopicCount = originalLockedTopics.size();
+        
+        // Check each week and day in the original locked topics map
+        for (Map.Entry<Integer, Map<DayOfWeek, List<CourseTopicEntity>>> weekEntry : originalLockedTopicsByWeekAndDay.entrySet()) {
+            int weekNumber = weekEntry.getKey();
+            
+            // Find the corresponding week in the new schedule
+            CourseWeekEntity newWeek = project.getWeeks().stream()
+                .filter(week -> week.getWeekNumber() == weekNumber)
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                    "Schedule generation failed to preserve week " + weekNumber + " which contains locked topics"));
+            
+            // Check each day in this week that had locked topics
+            for (Map.Entry<DayOfWeek, List<CourseTopicEntity>> dayEntry : weekEntry.getValue().entrySet()) {
+                DayOfWeek dayOfWeek = dayEntry.getKey();
+                List<CourseTopicEntity> originalTopicsForDay = dayEntry.getValue();
+                
+                // Find the corresponding session in the new schedule
+                ClassSessionEntity newSession = newWeek.getClassSessions().stream()
+                    .filter(session -> session.getDayOfWeek() == dayOfWeek)
+                    .findFirst()
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                        "Schedule generation failed to preserve " + dayOfWeek + " session in week " + weekNumber + 
+                        " which contains locked topics"));
+                
+                // Check if all original locked topics for this day are present in the new session
+                for (CourseTopicEntity originalTopic : originalTopicsForDay) {
+                    // Look for a topic with the same title in the new session
+                    boolean topicFound = newSession.getTopics().stream()
+                        .anyMatch(newTopic -> newTopic.getTitle().equals(originalTopic.getTitle()) && 
+                                              newTopic.getDurationMinutes() == originalTopic.getDurationMinutes() &&
+                                              newTopic.getTeacherLocked());
+                    
+                    if (!topicFound) {
+                        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                            "Schedule generation failed to preserve locked topic '" + originalTopic.getTitle() + 
+                            "' in " + dayOfWeek + " session of week " + weekNumber);
+                    }
+                    
+                    // Mark this original topic as found
+                    foundLockedTopicIds.add(originalTopic.getId());
+                }
+                
+                // Get the total minutes in this session and the minutes taken by locked topics
+                int totalSessionMinutes = newSession.getTopics().stream()
+                    .mapToInt(CourseTopicEntity::getDurationMinutes)
+                    .sum();
+                
+                int lockedTopicsMinutes = originalTopicsForDay.stream()
+                    .mapToInt(CourseTopicEntity::getDurationMinutes)
+                    .sum();
+                
+                int minutesPerSession = project.getDailyHours() * 60;
+                
+                // Special handling for when locked topics exceed the session duration
+                if (lockedTopicsMinutes > minutesPerSession) {
+                    // In this case, we allow the session to exceed the time limit, but we log a warning
+                    System.out.println("WARNING: Session on " + dayOfWeek + " of week " + weekNumber + 
+                        " has locked topics that exceed the session duration. " +
+                        "Locked topics take " + lockedTopicsMinutes + " minutes, but session limit is " + 
+                        minutesPerSession + " minutes.");
+                    
+                    // The only requirement is that all the locked topics are present
+                } else {
+                    // Normal case - session should match the expected duration exactly
+                    if (totalSessionMinutes != minutesPerSession) {
+                        throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                            "Session duration mismatch in " + dayOfWeek + " of week " + weekNumber + 
+                            ". Expected " + minutesPerSession + " minutes, got " + totalSessionMinutes + " minutes.");
+                    }
+                }
+            }
+        }
+        
+        // Final check: ensure we found all original locked topics
+        if (foundLockedTopicIds.size() != originalLockedTopicCount) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, 
+                "Schedule generation failed to preserve all locked topics. Expected " + 
+                originalLockedTopicCount + " locked topics, found " + foundLockedTopicIds.size());
+        }
+        
+        // All validations passed - the schedule correctly preserves all locked topics
+        System.out.println("Validation successful: All " + originalLockedTopicCount + " locked topics were properly preserved");
+    }
+    
+    /**
      * Processes topics from the JSON response and adds them to the session entity.
+     * The AI has already incorporated locked topics in its response based on our prompt.
+     * We also check against original locked topics to ensure the locked status is preserved.
      * 
      * @param sessionEntity The class session entity.
      * @param topicsNode The JSON node containing topics.
+     * @param lockedTopicTitles Map of topic titles that were locked in the original schedule
      */
-    private void processTopics(ClassSessionEntity sessionEntity, JsonNode topicsNode) {
+    private void processTopics(ClassSessionEntity sessionEntity, JsonNode topicsNode, Map<String, Boolean> lockedTopicTitles) {
         for (JsonNode topicNode : topicsNode) {
             String title = topicNode.path("title").asText();
             String description = topicNode.path("description").asText();
             int orderIndex = topicNode.path("orderIndex").asInt();
             int durationMinutes = topicNode.path("durationMinutes").asInt();
+            
+            // Check if this is a locked topic by examining:
+            // 1. If it was locked in the original schedule (by title)
+            // 2. If the AI response has explicit teacherLocked value
+            boolean wasOriginallyLocked = lockedTopicTitles.containsKey(title);
+            boolean aiMarkedAsLocked = topicNode.has("teacherLocked") ? 
+                    topicNode.path("teacherLocked").asBoolean() : false;
+            
+            // A topic should remain locked if it was locked in the original schedule
+            boolean shouldBeLocked = wasOriginallyLocked || aiMarkedAsLocked;
             
             CourseTopicEntity topicEntity = CourseTopicEntity.builder()
                     .classSession(sessionEntity)
@@ -615,6 +851,7 @@ public class TeachingProjectService {
                     .description(description)
                     .orderIndex(orderIndex)
                     .durationMinutes(durationMinutes)
+                    .teacherLocked(shouldBeLocked) // Preserve the locked status
                     .build();
             
             sessionEntity.getTopics().add(topicEntity);

--- a/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/service/TopicManagementService.java
+++ b/neuralforge_api/src/main/java/com/cenfotec/p3/neuralforge_api/service/TopicManagementService.java
@@ -1,0 +1,260 @@
+package com.cenfotec.p3.neuralforge_api.service;
+
+import com.cenfotec.p3.neuralforge_api.model.entity.ClassSessionEntity;
+import com.cenfotec.p3.neuralforge_api.model.entity.CourseTopicEntity;
+import com.cenfotec.p3.neuralforge_api.model.entity.CourseWeekEntity;
+import com.cenfotec.p3.neuralforge_api.model.entity.TeachingProjectEntity;
+import com.cenfotec.p3.neuralforge_api.model.mapper.CourseTopicMapper;
+import com.cenfotec.p3.neuralforge_api.model.mapper.TeachingProjectMapper;
+import com.cenfotec.p3.neuralforge_api.model.resource.CourseTopicResource;
+import com.cenfotec.p3.neuralforge_api.model.resource.TeachingProjectResource;
+import com.cenfotec.p3.neuralforge_api.repository.CourseTopicRepository;
+import com.cenfotec.p3.neuralforge_api.repository.TeachingProjectRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service class for managing teaching project topics - operations like moving, reordering, and locking topics.
+ * 
+ * @author Enrique Alpízar
+ * @version 1.0
+ */
+@Service
+public class TopicManagementService {
+
+    @Autowired
+    private TeachingProjectRepository teachingProjectRepository;
+
+    @Autowired
+    private CourseTopicRepository courseTopicRepository;
+
+    @Autowired
+    private TeachingProjectMapper teachingProjectMapper;
+
+    @Autowired
+    private CourseTopicMapper courseTopicMapper;
+
+    @Autowired
+    private TeachingProjectService teachingProjectService;
+
+    /**
+     * Toggles the locked state of a topic.
+     *
+     * @param topicId The ID of the topic to toggle lock state.
+     * @return The updated topic resource.
+     */
+    @Transactional
+    public CourseTopicResource toggleTopicLock(String topicId) {
+        CourseTopicEntity topic = findTopicAndValidateAccess(topicId);
+        
+        // Toggle the locked state
+        topic.setTeacherLocked(!topic.getTeacherLocked());
+        
+        // Save the updated topic
+        CourseTopicEntity savedTopic = courseTopicRepository.save(topic);
+        return courseTopicMapper.mapToResource(savedTopic);
+    }
+    
+    /**
+     * Moves a topic from one session to another.
+     *
+     * @param topicId The ID of the topic to move.
+     * @param targetWeekNumber The target week number.
+     * @param targetSessionId The target session ID.
+     * @return The updated teaching project resource.
+     */
+    @Transactional
+    public TeachingProjectResource moveTopicToSession(String topicId, int targetWeekNumber, String targetSessionId) {
+        CourseTopicEntity topic = findTopicAndValidateAccess(topicId);
+        
+        // Check if topic is locked
+        if (topic.getTeacherLocked()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Cannot move locked topic. Please unlock it first.");
+        }
+        
+        // Get the current session and project
+        ClassSessionEntity sourceSession = topic.getClassSession();
+        CourseWeekEntity sourceWeek = sourceSession.getCourseWeek();
+        TeachingProjectEntity project = sourceWeek.getTeachingProject();
+        
+        // Find the target session
+        ClassSessionEntity targetSession = findClassSessionById(project, targetWeekNumber, targetSessionId);
+        if (targetSession == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Target session not found");
+        }
+        
+        // Set the new order index (add to the end of the target session)
+        int newOrderIndex = targetSession.getTopics().size() + 1;
+        topic.setOrderIndex(newOrderIndex);
+        
+        // Move the topic to the target session
+        topic.setClassSession(targetSession);
+        targetSession.getTopics().add(topic);
+        
+        // Remove the topic from the source session
+        sourceSession.getTopics().remove(topic);
+        
+        // Reorder topics in source session
+        reorderTopicsInSession(sourceSession);
+        
+        // Save the updated topic
+        courseTopicRepository.save(topic);
+        
+        // Save the project and return the updated resource
+        TeachingProjectEntity savedProject = teachingProjectRepository.save(project);
+        return teachingProjectMapper.mapToResource(savedProject);
+    }
+    
+    /**
+     * Moves a topic up in its session (decrease order index).
+     *
+     * @param topicId The ID of the topic to move up.
+     * @return The updated teaching project resource.
+     */
+    @Transactional
+    public TeachingProjectResource moveTopicUp(String topicId) {
+        CourseTopicEntity topic = findTopicAndValidateAccess(topicId);
+        
+        // Check if topic is locked
+        if (topic.getTeacherLocked()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Cannot move locked topic. Please unlock it first.");
+        }
+        
+        ClassSessionEntity session = topic.getClassSession();
+        TeachingProjectEntity project = session.getCourseWeek().getTeachingProject();
+        
+        // Check if topic can be moved up
+        if (topic.getOrderIndex() <= 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Topic is already at the top of the session.");
+        }
+        
+        // Find the topic above
+        CourseTopicEntity topicAbove = session.getTopics().stream()
+                .filter(t -> t.getOrderIndex() == topic.getOrderIndex() - 1)
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, 
+                    "Topic with order index " + (topic.getOrderIndex() - 1) + " not found."));
+        
+        // Check if topic above is locked
+        if (topicAbove.getTeacherLocked()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Cannot move topic up because the topic above is locked.");
+        }
+        
+        // Swap order indices
+        int tempOrderIndex = topic.getOrderIndex();
+        topic.setOrderIndex(topicAbove.getOrderIndex());
+        topicAbove.setOrderIndex(tempOrderIndex);
+        
+        // Save the changes
+        courseTopicRepository.save(topic);
+        courseTopicRepository.save(topicAbove);
+        
+        // Save the project and return the updated resource
+        TeachingProjectEntity savedProject = teachingProjectRepository.save(project);
+        return teachingProjectMapper.mapToResource(savedProject);
+    }
+    
+    /**
+     * Moves a topic down in its session (increase order index).
+     *
+     * @param topicId The ID of the topic to move down.
+     * @return The updated teaching project resource.
+     */
+    @Transactional
+    public TeachingProjectResource moveTopicDown(String topicId) {
+        CourseTopicEntity topic = findTopicAndValidateAccess(topicId);
+        
+        // Check if topic is locked
+        if (topic.getTeacherLocked()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Cannot move locked topic. Please unlock it first.");
+        }
+        
+        ClassSessionEntity session = topic.getClassSession();
+        TeachingProjectEntity project = session.getCourseWeek().getTeachingProject();
+        
+        // Check if topic can be moved down
+        int maxOrderIndex = session.getTopics().stream()
+                .mapToInt(CourseTopicEntity::getOrderIndex)
+                .max()
+                .orElse(0);
+        
+        if (topic.getOrderIndex() >= maxOrderIndex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Topic is already at the bottom of the session.");
+        }
+        
+        // Find the topic below
+        CourseTopicEntity topicBelow = session.getTopics().stream()
+                .filter(t -> t.getOrderIndex() == topic.getOrderIndex() + 1)
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, 
+                    "Topic with order index " + (topic.getOrderIndex() + 1) + " not found."));
+        
+        // Check if topic below is locked
+        if (topicBelow.getTeacherLocked()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                "Cannot move topic down because the topic below is locked.");
+        }
+        
+        // Swap order indices
+        int tempOrderIndex = topic.getOrderIndex();
+        topic.setOrderIndex(topicBelow.getOrderIndex());
+        topicBelow.setOrderIndex(tempOrderIndex);
+        
+        // Save the changes
+        courseTopicRepository.save(topic);
+        courseTopicRepository.save(topicBelow);
+        
+        // Save the project and return the updated resource
+        TeachingProjectEntity savedProject = teachingProjectRepository.save(project);
+        return teachingProjectMapper.mapToResource(savedProject);
+    }
+    
+    /**
+     * Helper method to validate topic access and find it by ID.
+     */
+    private CourseTopicEntity findTopicAndValidateAccess(String topicId) {
+        CourseTopicEntity topic = courseTopicRepository.findById(topicId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, 
+                    "Topic not found with id: " + topicId));
+        
+        // Validate that the current user has access to the project
+        TeachingProjectEntity project = topic.getClassSession().getCourseWeek().getTeachingProject();
+        teachingProjectService.validateProjectOwnership(project.getCreatorUserId());
+        
+        return topic;
+    }
+    
+    /**
+     * Helper method to reorder topics in a session after one has been removed.
+     */
+    private void reorderTopicsInSession(ClassSessionEntity session) {
+        List<CourseTopicEntity> topics = session.getTopics();
+        for (int i = 0; i < topics.size(); i++) {
+            topics.get(i).setOrderIndex(i + 1);
+        }
+    }
+    
+    /**
+     * Helper method to find a class session by week number and session ID.
+     */
+    private ClassSessionEntity findClassSessionById(TeachingProjectEntity project, int weekNumber, String sessionId) {
+        return project.getWeeks().stream()
+                .filter(week -> week.getWeekNumber() == weekNumber)
+                .flatMap(week -> week.getClassSessions().stream())
+                .filter(session -> session.getId().equals(sessionId))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.html
+++ b/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.html
@@ -1,7 +1,22 @@
 <h2 mat-dialog-title>Move Topic</h2>
 <mat-dialog-content>
-  <p>Select where to move "{{ data.topic.title }}"</p>
+  <div class="topic-info">
+    <h3>"{{ data.topic.title }}"</h3>
+    <div class="current-location">
+      <strong>Currently in:</strong> Week {{ data.currentWeekNumber }}, 
+      {{ getDayOfWeekName(getCurrentSession()?.dayOfWeek || '') }}
+      <span *ngIf="getSessionDate(data.currentWeekNumber, getCurrentSession()?.dayOfWeek || '')">
+        ({{
+          getSessionDate(data.currentWeekNumber, getCurrentSession()?.dayOfWeek || '')
+            | date : "MMM d, yyyy"
+        }})
+      </span>
+    </div>
+  </div>
 
+  <div class="divider"></div>
+  
+  <h3>Move to:</h3>
   <div class="form-container">
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Week</mat-label>
@@ -30,9 +45,13 @@
       </mat-select>
     </mat-form-field>
   </div>
+  
+  <div class="note" *ngIf="isSameLocation()">
+    <mat-icon>warning</mat-icon> This is the current location of the topic.
+  </div>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
   <button mat-button [mat-dialog-close]="false">Cancel</button>
-  <button mat-button color="primary" (click)="onSubmit()">Move</button>
+  <button mat-button color="primary" [disabled]="isSameLocation()" (click)="onSubmit()">Move</button>
 </mat-dialog-actions>

--- a/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.scss
+++ b/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.scss
@@ -12,3 +12,44 @@
 mat-dialog-content {
   margin-bottom: 16px;
 }
+
+.topic-info {
+  margin-bottom: 16px;
+  padding: 12px;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  
+  h3 {
+    margin-top: 0;
+    margin-bottom: 8px;
+    color: #333;
+  }
+  
+  .current-location {
+    color: #555;
+  }
+}
+
+.divider {
+  height: 1px;
+  background-color: #e0e0e0;
+  margin: 16px 0;
+}
+
+.note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 8px 12px;
+  background-color: #fff3e0;
+  border-radius: 4px;
+  color: #e65100;
+  font-size: 14px;
+  
+  mat-icon {
+    font-size: 18px;
+    height: 18px;
+    width: 18px;
+  }
+}

--- a/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.ts
+++ b/neuralforge_ui/src/app/components/dialogs/move-topic-dialog/move-topic-dialog.component.ts
@@ -8,6 +8,7 @@ import {
   MatDialogRef,
 } from "@angular/material/dialog";
 import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
 import { MatSelectModule } from "@angular/material/select";
 import { IClassSession, ICourseTopic, ICourseWeek } from "../../../interfaces";
 
@@ -21,6 +22,7 @@ import { IClassSession, ICourseTopic, ICourseWeek } from "../../../interfaces";
     MatFormFieldModule,
     MatSelectModule,
     FormsModule,
+    MatIconModule,
   ],
   templateUrl: "./move-topic-dialog.component.html",
   styleUrls: ["./move-topic-dialog.component.scss"],
@@ -118,7 +120,28 @@ export class MoveTopicDialogComponent {
     return projectStartDate;
   }
 
+  getCurrentSession(): IClassSession | undefined {
+    const currentWeek = this.data.weeks.find(
+      (week) => week.weekNumber === this.data.currentWeekNumber
+    );
+    
+    if (!currentWeek) return undefined;
+    
+    return currentWeek.classSessions.find(
+      (session) => session.id === this.data.currentSessionId
+    );
+  }
+
+  isSameLocation(): boolean {
+    return (
+      this.selectedWeekNumber === this.data.currentWeekNumber &&
+      this.selectedSessionId === this.data.currentSessionId
+    );
+  }
+
   onSubmit() {
+    if (this.isSameLocation()) return;
+    
     this.dialogRef.close({
       topic: this.data.topic,
       sourceWeekNumber: this.data.currentWeekNumber,

--- a/neuralforge_ui/src/app/components/teaching-calendar/teaching-calendar.component.html
+++ b/neuralforge_ui/src/app/components/teaching-calendar/teaching-calendar.component.html
@@ -23,7 +23,7 @@
 
   <!-- Week-based schedule display -->
   <ng-container *ngIf="project && project.weeks && project.weeks.length > 0">
-    <div *ngFor="let week of project.weeks; let weekIndex = index">
+    <div *ngFor="let week of getSortedWeeks(); let weekIndex = index">
       <mat-card class="schedule-card">
         <div class="week-header">
           <h3>
@@ -59,7 +59,7 @@
             <div class="topics-container">
               <ng-container *ngIf="session.topics.length > 0">
                 <div
-                  *ngFor="let topic of session.topics; let topicIndex = index"
+                  *ngFor="let topic of getSortedTopics(session); let topicIndex = index"
                   class="topic-item"
                 >
                   <div class="topic-header">

--- a/neuralforge_ui/src/app/components/teaching-calendar/teaching-calendar.component.ts
+++ b/neuralforge_ui/src/app/components/teaching-calendar/teaching-calendar.component.ts
@@ -23,6 +23,7 @@ import {
 import { AlertService } from "../../services/alert.service";
 import { ProjectMaterialService } from "../../services/project-material.service";
 import { TeachingProjectService } from "../../services/teaching-project.service";
+import { TopicManagementService } from "../../services/topic-management.service";
 import { MoveTopicDialogComponent } from "../dialogs/move-topic-dialog/move-topic-dialog.component";
 
 interface IWeek {
@@ -64,7 +65,8 @@ export class TeachingCalendarComponent implements OnInit, OnDestroy {
     private teachingProjectService: TeachingProjectService,
     private alertService: AlertService,
     private dialog: MatDialog,
-    private projectMaterialService: ProjectMaterialService
+    private projectMaterialService: ProjectMaterialService,
+    private topicManagementService: TopicManagementService
   ) {}
 
   ngOnInit() {
@@ -156,6 +158,17 @@ export class TeachingCalendarComponent implements OnInit, OnDestroy {
   ) {
     if (!this.project?.weeks) return;
 
+    if (topic.teacherLocked) {
+      this.alertService.displayAlert(
+        "warning",
+        "This topic is locked. Please unlock it before moving.",
+        "center",
+        "top",
+        ["warning-snackbar"]
+      );
+      return;
+    }
+
     const dialogRef = this.dialog.open(MoveTopicDialogComponent, {
       width: "450px",
       data: {
@@ -169,39 +182,222 @@ export class TeachingCalendarComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe((result) => {
       if (result) {
-        this.alertService.displayAlert(
-          "info",
-          "Move topic to different day not implemented yet",
-          "center",
-          "top",
-          ["info-snackbar"]
-        );
+        this.isGeneratingSchedule = true; // Show loading
+
+        this.topicManagementService
+          .moveTopicToSession(
+            topicId,
+            result.targetWeekNumber,
+            result.targetSessionId
+          )
+          .subscribe({
+            next: (updatedProject) => {
+              if (this.project) {
+                this.project = updatedProject;
+              }
+              this.isGeneratingSchedule = false;
+              this.alertService.displayAlert(
+                "success",
+                "Topic moved successfully",
+                "center",
+                "top",
+                ["success-snackbar"]
+              );
+            },
+            error: (error) => {
+              console.error("Error moving topic:", error);
+              this.isGeneratingSchedule = false;
+              this.alertService.displayAlert(
+                "error",
+                error.error?.message ||
+                  "Failed to move topic. Please try again.",
+                "center",
+                "top",
+                ["error-snackbar"]
+              );
+            },
+          });
       }
     });
   }
 
   moveTopicUp(weekIndex: number, sessionIndex: number, topicIndex: number) {
-    this.alertService.displayAlert(
-      "info",
-      "Move topic up not implemented yet",
-      "center",
-      "top",
-      ["info-snackbar"]
-    );
+    if (!this.project?.weeks) return;
+
+    const sortedWeeks = this.getSortedWeeks();
+    const week = sortedWeeks[weekIndex];
+    if (!week) return;
+
+    const sortedSessions = this.getSortedClassSessions(week);
+    const session = sortedSessions[sessionIndex];
+    if (!session) return;
+
+    const sortedTopics = this.getSortedTopics(session);
+    const topic = sortedTopics[topicIndex];
+    if (!topic || !topic.id) return;
+
+    // Check if topic is locked
+    if (topic.teacherLocked) {
+      this.alertService.displayAlert(
+        "warning",
+        "This topic is locked. Please unlock it before moving.",
+        "center",
+        "top",
+        ["warning-snackbar"]
+      );
+      return;
+    }
+
+    // Check if topic above is locked
+    if (topicIndex > 0) {
+      const topicAbove = sortedTopics[topicIndex - 1];
+      if (topicAbove.teacherLocked) {
+        this.alertService.displayAlert(
+          "warning",
+          "Cannot move topic up because the topic above is locked.",
+          "center",
+          "top",
+          ["warning-snackbar"]
+        );
+        return;
+      }
+    }
+
+    this.isGeneratingSchedule = true; // Show loading
+
+    this.topicManagementService.moveTopicUp(topic.id).subscribe({
+      next: (updatedProject) => {
+        if (this.project) {
+          this.project = updatedProject;
+        }
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "success",
+          "Topic moved up successfully",
+          "center",
+          "top",
+          ["success-snackbar"]
+        );
+      },
+      error: (error) => {
+        console.error("Error moving topic up:", error);
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "error",
+          error.error?.message || "Failed to move topic up. Please try again.",
+          "center",
+          "top",
+          ["error-snackbar"]
+        );
+      },
+    });
   }
 
   moveTopicDown(weekIndex: number, sessionIndex: number, topicIndex: number) {
-    this.alertService.displayAlert(
-      "info",
-      "Move topic down not implemented yet",
-      "center",
-      "top",
-      ["info-snackbar"]
-    );
+    if (!this.project?.weeks) return;
+
+    const sortedWeeks = this.getSortedWeeks();
+    const week = sortedWeeks[weekIndex];
+    if (!week) return;
+
+    const sortedSessions = this.getSortedClassSessions(week);
+    const session = sortedSessions[sessionIndex];
+    if (!session) return;
+
+    const sortedTopics = this.getSortedTopics(session);
+    const topic = sortedTopics[topicIndex];
+    if (!topic || !topic.id) return;
+
+    // Check if topic is locked
+    if (topic.teacherLocked) {
+      this.alertService.displayAlert(
+        "warning",
+        "This topic is locked. Please unlock it before moving.",
+        "center",
+        "top",
+        ["warning-snackbar"]
+      );
+      return;
+    }
+
+    // Check if topic below is locked
+    if (topicIndex < sortedTopics.length - 1) {
+      const topicBelow = sortedTopics[topicIndex + 1];
+      if (topicBelow.teacherLocked) {
+        this.alertService.displayAlert(
+          "warning",
+          "Cannot move topic down because the topic below is locked.",
+          "center",
+          "top",
+          ["warning-snackbar"]
+        );
+        return;
+      }
+    }
+
+    this.isGeneratingSchedule = true; // Show loading
+
+    this.topicManagementService.moveTopicDown(topic.id).subscribe({
+      next: (updatedProject) => {
+        if (this.project) {
+          this.project = updatedProject;
+        }
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "success",
+          "Topic moved down successfully",
+          "center",
+          "top",
+          ["success-snackbar"]
+        );
+      },
+      error: (error) => {
+        console.error("Error moving topic down:", error);
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "error",
+          error.error?.message ||
+            "Failed to move topic down. Please try again.",
+          "center",
+          "top",
+          ["error-snackbar"]
+        );
+      },
+    });
   }
 
   toggleLock(topic: ICourseTopic) {
-    topic.teacherLocked = !topic.teacherLocked;
+    if (!topic.id) return;
+
+    this.isGeneratingSchedule = true; // Show loading
+
+    this.topicManagementService.toggleTopicLock(topic.id).subscribe({
+      next: (updatedTopic) => {
+        topic.teacherLocked = updatedTopic.teacherLocked;
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "success",
+          topic.teacherLocked
+            ? "Topic locked successfully"
+            : "Topic unlocked successfully",
+          "center",
+          "top",
+          ["success-snackbar"]
+        );
+      },
+      error: (error) => {
+        console.error("Error toggling topic lock:", error);
+        this.isGeneratingSchedule = false;
+        this.alertService.displayAlert(
+          "error",
+          error.error?.message ||
+            "Failed to toggle topic lock. Please try again.",
+          "center",
+          "top",
+          ["error-snackbar"]
+        );
+      },
+    });
   }
 
   private generateWeeks() {
@@ -301,6 +497,25 @@ export class TeachingCalendarComponent implements OnInit, OnDestroy {
     projectStartDate.setDate(projectStartDate.getDate() + daysToAdd);
 
     return projectStartDate;
+  }
+
+  getSortedWeeks(): ICourseWeek[] {
+    if (!this.project?.weeks || this.project.weeks.length === 0) {
+      return [];
+    }
+
+    return [...this.project.weeks].sort((a, b) => a.weekNumber - b.weekNumber);
+  }
+
+  /**
+   * Returns the sessions topics sorted by orderIndex
+   */
+  getSortedTopics(session: IClassSession): ICourseTopic[] {
+    if (!session.topics || session.topics.length === 0) {
+      return [];
+    }
+
+    return [...session.topics].sort((a, b) => a.orderIndex - b.orderIndex);
   }
 
   getSortedClassSessions(week: ICourseWeek): IClassSession[] {

--- a/neuralforge_ui/src/app/services/topic-management.service.ts
+++ b/neuralforge_ui/src/app/services/topic-management.service.ts
@@ -1,0 +1,51 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { ICourseTopic, ITeachingProject } from "../interfaces";
+
+@Injectable({
+  providedIn: "root",
+})
+export class TopicManagementService {
+  private apiUrl = "api/neuralforge/v1/topic-management";
+
+  constructor(private http: HttpClient) {}
+
+  toggleTopicLock(topicId: string): Observable<ICourseTopic> {
+    return this.http.put<ICourseTopic>(
+      `${this.apiUrl}/topics/${topicId}/toggle-lock`,
+      {}
+    );
+  }
+
+  moveTopicToSession(
+    topicId: string,
+    targetWeekNumber: number,
+    targetSessionId: string
+  ): Observable<ITeachingProject> {
+    return this.http.put<ITeachingProject>(
+      `${this.apiUrl}/topics/${topicId}/move-to-session`,
+      {},
+      {
+        params: {
+          targetWeekNumber: targetWeekNumber.toString(),
+          targetSessionId,
+        },
+      }
+    );
+  }
+
+  moveTopicUp(topicId: string): Observable<ITeachingProject> {
+    return this.http.put<ITeachingProject>(
+      `${this.apiUrl}/topics/${topicId}/move-up`,
+      {}
+    );
+  }
+
+  moveTopicDown(topicId: string): Observable<ITeachingProject> {
+    return this.http.put<ITeachingProject>(
+      `${this.apiUrl}/topics/${topicId}/move-down`,
+      {}
+    );
+  }
+}


### PR DESCRIPTION
- Move Topics Up/Down Within a Week:
Users can now reorder topics within the same week using simple up/down controls.

- Move Topics Between Weeks:
 Topics can be shifted across different weeks, allowing for dynamic restructuring of the plan.
 
- Lock Topics to Specific Weeks:
Topics can be locked to a specific week to prevent accidental movement. Locked topics will stay fixed during any reordering or regeneration process.

- Regenerate Plan with Locked Topics Respected:
The teaching plan regeneration logic now takes locked topics into account, preserving their positions while adjusting the rest of the plan.


![image](https://github.com/user-attachments/assets/82a1b079-e55e-4308-b184-c62345e56cee)
![image](https://github.com/user-attachments/assets/b39fd522-c9ee-4872-8833-97612c5ff0b4)
![image](https://github.com/user-attachments/assets/b1ce8790-8cf8-49ae-ac2c-83eea3ef47e0)
